### PR TITLE
simnet+Makefile+docker: Adding Docker Simnet for LND Nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+simnet/*/data
+simnet/*/tls.cert
+simnet/*/tls.key
+
+*.swp

--- a/Makefile
+++ b/Makefile
@@ -21,4 +21,4 @@ dev-up:
 
 # Attach to the simnet container
 attach-simnet:
-	@docker exec -ti simnet /bin/bash
+	@docker exec -ti simnet /bin/sh

--- a/docker/docker-compose-simnet.yaml
+++ b/docker/docker-compose-simnet.yaml
@@ -1,0 +1,10 @@
+version: '2'
+services:
+  simnet:
+    container_name: simnet
+    build: ../simnet
+    command: "/simnet/scripts/main.sh"
+    volumes:
+      - ../simnet:/simnet  
+    ports:
+        - 127.0.0.1:10009:10009

--- a/simnet/Dockerfile
+++ b/simnet/Dockerfile
@@ -1,8 +1,8 @@
-FROM golang:latest
+FROM golang:1.11-alpine as builder
 
 # Install dependenices.
-RUN apt update \
-    && apt-get install net-tools make git gcc autoconf build-essential libtool autotools-dev automake pkg-config bsdmainutils python3 -y
+RUN apk update \
+    && apk add --no-cache git make gcc autoconf libtool automake python3 musl-dev linux-headers
 
 # Set Working Directory to Go folder.
 WORKDIR /root/go/src/github.com/lightningnetwork
@@ -24,6 +24,13 @@ RUN git clone https://github.com/btcsuite/btcd.git
 # Install btcd.
 WORKDIR /root/go/src/github.com/btcd
 RUN go install . ./cmd/...
+
+FROM alpine:latest
+
+COPY --from=builder /go/bin/btcctl /bin/btcctl
+COPY --from=builder /go/bin/btcd /bin/btcd
+COPY --from=builder /go/bin/lnd /bin/lnd
+COPY --from=builder /go/bin/lncli /bin/lncli
 
 # Set the entry workdir to simnet.
 WORKDIR /simnet

--- a/simnet/alice/alice.sh
+++ b/simnet/alice/alice.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Alices cli.
 lncli --rpcserver=localhost:10009 --tlscertpath=./tls.cert --macaroonpath=./data/chain/bitcoin/simnet/admin.macaroon $@

--- a/simnet/alice/start.sh
+++ b/simnet/alice/start.sh
@@ -1,5 +1,6 @@
-#!/bin/bash
+#!/bin/sh
 
 # Start alices node.
 # NOTE: (ccdle12) testing the autopilot feature.
-lnd --autopilot.active --autopilot.maxchannels=20 --autopilot.allocation=0.6 --rpclisten=127.0.0.1:10008 --rpclisten=0.0.0.0:10009 --datadir=./data --tlscertpath=./tls.cert --tlskeypath=./tls.key --listen=0.0.0.0:10011 --restlisten=localhost:8001 --debuglevel=debug --externalip=localhost:10011 --tlsextraip=0.0.0.0 --bitcoin.simnet --bitcoin.active --bitcoin.node=btcd --btcd.rpcuser=kek --btcd.rpcpass=kek
+# lnd --autopilot.active --autopilot.maxchannels=20 --autopilot.allocation=0.6 --rpclisten=127.0.0.1:10008 --rpclisten=0.0.0.0:10009 --datadir=./data --tlscertpath=./tls.cert --tlskeypath=./tls.key --listen=0.0.0.0:10011 --restlisten=localhost:8001 --debuglevel=debug --externalip=localhost:10011 --tlsextraip=0.0.0.0 --bitcoin.simnet --bitcoin.active --bitcoin.node=btcd --btcd.rpcuser=kek --btcd.rpcpass=kek
+lnd --rpclisten=127.0.0.1:10008 --rpclisten=0.0.0.0:10009 --datadir=./data --tlscertpath=./tls.cert --tlskeypath=./tls.key --listen=0.0.0.0:10011 --restlisten=localhost:8001 --debuglevel=debug --externalip=localhost:10011 --tlsextraip=0.0.0.0 --bitcoin.simnet --bitcoin.active --bitcoin.node=btcd --btcd.rpcuser=kek --btcd.rpcpass=kek

--- a/simnet/alice/start.sh
+++ b/simnet/alice/start.sh
@@ -1,6 +1,4 @@
 #!/bin/sh
 
 # Start alices node.
-# NOTE: (ccdle12) testing the autopilot feature.
-# lnd --autopilot.active --autopilot.maxchannels=20 --autopilot.allocation=0.6 --rpclisten=127.0.0.1:10008 --rpclisten=0.0.0.0:10009 --datadir=./data --tlscertpath=./tls.cert --tlskeypath=./tls.key --listen=0.0.0.0:10011 --restlisten=localhost:8001 --debuglevel=debug --externalip=localhost:10011 --tlsextraip=0.0.0.0 --bitcoin.simnet --bitcoin.active --bitcoin.node=btcd --btcd.rpcuser=kek --btcd.rpcpass=kek
 lnd --rpclisten=127.0.0.1:10008 --rpclisten=0.0.0.0:10009 --datadir=./data --tlscertpath=./tls.cert --tlskeypath=./tls.key --listen=0.0.0.0:10011 --restlisten=localhost:8001 --debuglevel=debug --externalip=localhost:10011 --tlsextraip=0.0.0.0 --bitcoin.simnet --bitcoin.active --bitcoin.node=btcd --btcd.rpcuser=kek --btcd.rpcpass=kek

--- a/simnet/bob/bob.sh
+++ b/simnet/bob/bob.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 lncli --rpcserver=localhost:10002 --tlscertpath=./tls.cert --macaroonpath=./data/chain/bitcoin/simnet/admin.macaroon $@

--- a/simnet/bob/start.sh
+++ b/simnet/bob/start.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 lnd --rpclisten=localhost:10002 --listen=localhost:10012 --datadir=./data --tlscertpath=./tls.cert --tlskeypath=./tls.key  --restlisten=localhost:8002 --alias=bob --debuglevel=debug --externalip=localhost:10012 --tlsextraip=0.0.0.0 --bitcoin.simnet --bitcoin.active --bitcoin.node=btcd --btcd.rpcuser=kek --btcd.rpcpass=kek

--- a/simnet/charlie/charlie.sh
+++ b/simnet/charlie/charlie.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 lncli --rpcserver=localhost:10003 --tlscertpath=./tls.cert --macaroonpath=./data/chain/bitcoin/simnet/admin.macaroon $@

--- a/simnet/charlie/start.sh
+++ b/simnet/charlie/start.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 lnd --rpclisten=localhost:10003 --listen=localhost:10013 --datadir=./data --tlscertpath=./tls.cert --tlskeypath=./tls.key  --restlisten=localhost:8003 --alias=bob --debuglevel=debug --externalip=localhost:10013 --tlsextraip=0.0.0.0 --bitcoin.simnet --bitcoin.active --bitcoin.node=btcd --btcd.rpcuser=kek --btcd.rpcpass=kek

--- a/simnet/scripts/btc.sh
+++ b/simnet/scripts/btc.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 btcctl --simnet --rpcuser=kek --rpcpass=kek $@

--- a/simnet/scripts/btcd.sh
+++ b/simnet/scripts/btcd.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
 btcd --txindex --simnet --rpcuser=kek --rpcpass=kek --debuglevel=debug $@

--- a/simnet/scripts/main.sh
+++ b/simnet/scripts/main.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Add a btcd.conf file in .btcd.
 mkdir /root/.btcd

--- a/simnet/scripts/reset.sh
+++ b/simnet/scripts/reset.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Reset the simnet.
 cd /simnet


### PR DESCRIPTION
Fixes #1

This PR adds the docker-compose file in the docker folder that runs the simnet LND nodes.

This PR also includes supporting fixes:

- Refactors the Dockerfile for simnet to use the builder pattern, reduces size of image from 1.56GB -> 87.7MB

- Adds a .gitignore file, specifically to ignore the generated stateful files for the simnet nodes

- Replaces all scripts associated with simnet to use `sh` instead of `bash`